### PR TITLE
Create PEPTOGP.sh

### DIFF
--- a/scripts/Hoang/PEPTOGP.sh
+++ b/scripts/Hoang/PEPTOGP.sh
@@ -1,0 +1,10 @@
+#Uncomment out below when need to retreive GI
+#FASTA=*.fasta.new
+#for file in $FASTA
+#do grep -o "[0-9]* " $file | awk 'NF' > $file".txt"
+#done
+pept="OG1.5_1697.fasta.new.txt"
+#variable can be multiple arguments
+for file in $pept;
+do python getgenpept.py $file;
+done


### PR DESCRIPTION
To work in conjunction with getgenpept.py file (WIP)
formating issues are weird for NOTEPAD++ on windows, may not work; did work when rewritten on vim on the cluster
